### PR TITLE
Breaking: upgrade pkg-dir

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 	"repository": "avajs/find-cache-dir",
 	"funding": "https://github.com/avajs/find-cache-dir?sponsor=1",
 	"engines": {
-		"node": ">=8"
+		"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
 	},
 	"scripts": {
 		"test": "xo && nyc ava"
@@ -25,7 +25,7 @@
 	"dependencies": {
 		"commondir": "^1.0.1",
 		"make-dir": "^3.0.2",
-		"pkg-dir": "^4.1.0"
+		"pkg-dir": "^6.0.1"
 	},
 	"devDependencies": {
 		"ava": "^2.4.0",


### PR DESCRIPTION
This upgrades pkg-dir from 4 to 6, which only supports node 12+, which I've copied to the `engines` here as well.

I did not test this change, and I don't see any automated CI, so proceed with caution.  I just found that an older version of find-up was being installed in my project, and traced it down to this package, so I figured I'd submit a PR to update it.  Other than that, I have no familiarity with find-cache-dir.